### PR TITLE
Fix get requests with query parameters

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -147,7 +147,7 @@ class Client
                 break;
 
             case 'get':
-                curl_setopt($curlHandle, CURLOPT_URL, $fullUrl.'&'.http_build_query($arguments));
+                curl_setopt($curlHandle, CURLOPT_URL, $fullUrl.'?'.http_build_query($arguments));
                 break;
 
             case 'delete':


### PR DESCRIPTION
Hey!

I found a small bug while I copied some code of your client class:

For `get` requests, `$fullUrl` needs to have a parameter (e.g. https://example.com/test?key=value). I don't think this is intended.

I changed `&` to `?` so that now the `$fullUrl` will be concatenated with `http_build_query($arguments)`.