### PR TITLE
Allow custom grouping types

### DIFF
--- a/src/Enums/GroupingTypes.php
+++ b/src/Enums/GroupingTypes.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Facade\FlareClient\Enums;
+
+class GroupingTypes
+{
+    const TOP_FRAME = 'topFrame';
+
+    const EXCEPTION = 'exceptionClass';
+}

--- a/src/Flare.php
+++ b/src/Flare.php
@@ -230,6 +230,8 @@ class Flare
             $this->applicationPath
         );
 
+        $report->groupByException();
+
         return $this->applyMiddlewareToReport($report);
     }
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -2,6 +2,7 @@
 
 namespace Facade\FlareClient;
 
+use Facade\FlareClient\Enums\GroupingTypes;
 use Throwable;
 use Facade\FlareClient\Glows\Glow;
 use Facade\IgnitionContracts\Solution;
@@ -57,6 +58,9 @@ class Report
 
     /** @var int */
     private $openFrameIndex;
+
+    /** @var string */
+    private $groupBy;
 
     public static function createForThrowable(Throwable $throwable, ContextInterface $context, ?string $applicationPath = null): self
     {
@@ -206,6 +210,20 @@ class Report
         return $this;
     }
 
+    public function groupByTopFrame()
+    {
+        $this->groupBy = GroupingTypes::TOP_FRAME;
+
+        return $this;
+    }
+
+    public function groupByException()
+    {
+        $this->groupBy = GroupingTypes::EXCEPTION;
+
+        return $this;
+    }
+
     public function allContext(): array
     {
         $context = $this->context->toArray();
@@ -241,6 +259,7 @@ class Report
             'stage' => $this->stage,
             'message_level' => $this->messageLevel,
             'open_frame_index' => $this->openFrameIndex,
+            'group_by' => $this->groupBy ?? GroupingTypes::TOP_FRAME,
             'application_path' => $this->applicationPath,
         ];
     }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -3,6 +3,7 @@
 namespace Facade\FlareClient\Tests;
 
 use Exception;
+use Facade\FlareClient\Enums\GroupingTypes;
 use Facade\FlareClient\Report;
 use Facade\FlareClient\Glows\Glow;
 use Facade\FlareClient\Context\ConsoleContext;
@@ -38,6 +39,34 @@ class ReportTest extends TestCase
         $report = $report->toArray();
 
         $this->assertMatchesReportSnapshot($report);
+    }
+
+    /** @test */
+    public function it_can_create_a_report_with_custom_grouping_type()
+    {
+        $report = Report::createForMessage('this is a message', 'Log', new ConsoleContext());
+
+        $report->groupByException();
+
+        $reportData = $report->toArray();
+
+        $this->assertSame($reportData['group_by'], GroupingTypes::EXCEPTION);
+
+        $report->groupByTopFrame();
+
+        $reportData = $report->toArray();
+
+        $this->assertSame($reportData['group_by'], GroupingTypes::TOP_FRAME);
+    }
+
+    /** @test */
+    public function it_groups_by_top_frame_as_a_default()
+    {
+        $report = Report::createForMessage('this is a message', 'Log', new ConsoleContext());
+
+        $reportData = $report->toArray();
+
+        $this->assertSame($reportData['group_by'], GroupingTypes::TOP_FRAME);
     }
 
     /** @test */

--- a/tests/__snapshots__/FlareTest__it_can_report_an_exception__1.yml
+++ b/tests/__snapshots__/FlareTest__it_can_report_an_exception__1.yml
@@ -14,4 +14,5 @@ context:
 stage: null
 message_level: null
 open_frame_index: null
+group_by: topFrame
 application_path: null

--- a/tests/__snapshots__/ReportTest__it_can_create_a_report__1.yml
+++ b/tests/__snapshots__/ReportTest__it_can_create_a_report__1.yml
@@ -14,4 +14,5 @@ context:
 stage: null
 message_level: null
 open_frame_index: null
+group_by: topFrame
 application_path: null

--- a/tests/__snapshots__/ReportTest__it_can_create_a_report_for_a_string_message__1.yml
+++ b/tests/__snapshots__/ReportTest__it_can_create_a_report_for_a_string_message__1.yml
@@ -14,4 +14,5 @@ context:
 stage: null
 message_level: null
 open_frame_index: 0
+group_by: topFrame
 application_path: null

--- a/tests/__snapshots__/ReportTest__it_can_create_a_report_with_glows__1.yml
+++ b/tests/__snapshots__/ReportTest__it_can_create_a_report_with_glows__1.yml
@@ -21,4 +21,5 @@ context:
 stage: null
 message_level: null
 open_frame_index: null
+group_by: topFrame
 application_path: null


### PR DESCRIPTION
This PR allows modifying the custom grouping type when a report gets sent.

Reports generated from log messages get automatically grouped by the exception class so that multiple logs with different messages don't end up being grouped together.