### PR TITLE
Enable tests on PHP 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3, 7.2, 7.1]
+                php: [8.0, 7.4, 7.3, 7.2, 7.1]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,12 +26,17 @@ jobs:
               uses: shivammathur/setup-php@v1
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: fileinfo, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                  extensions: fileinfo, dom, curl, libxml, mbstring, bcmath, soap
                   coverage: none
+                  tools: composer:v2
 
-            - name: Install dependencies
-              run: |
-                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+            - name: Install PHP 7 dependencies
+              run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
+              if: "matrix.php < 8"
+
+            - name: Install PHP 8 dependencies
+              run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
+              if: "matrix.php >= 8"
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/facade/flare-client-php",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "facade/ignition-contracts": "~1.0",
         "illuminate/pipeline": "^5.5|^6.0|^7.0|^8.0",
         "symfony/http-foundation": "^3.3|^4.1|^5.0",


### PR DESCRIPTION
I've rejigged the tests so that they run successfully on PHP 8. This is temporary fix for now as it relies on disabling platform requirements using composer 2's `ignore-platform-req` option when running on 8, however, the tests still run and pass on all combinations.