### PR TITLE
Add support for error and exception filtering

### DIFF
--- a/src/Flare.php
+++ b/src/Flare.php
@@ -207,11 +207,15 @@ class Flare
 
     protected function shouldSendReport(Throwable $throwable): bool
     {
-        if ($this->throwableIsAnError($throwable) && $this->reportErrorLevels) {
+        if($this->reportErrorLevels && $throwable instanceof Error){
             return $this->reportErrorLevels & $throwable->getCode();
         }
 
-        if ($this->filterExceptionsCallable) {
+        if($this->reportErrorLevels && $throwable instanceof ErrorException){
+            return $this->reportErrorLevels & $throwable->getSeverity();
+        }
+
+        if ($this->filterExceptionsCallable && $throwable instanceof Exception) {
             return call_user_func($this->filterExceptionsCallable, $throwable);
         }
 
@@ -309,11 +313,5 @@ class Flare
             });
 
         return $report;
-    }
-
-
-    protected function throwableIsAnError(Throwable $throwable): bool
-    {
-        return $throwable instanceof ErrorException || $throwable instanceof Error;
     }
 }

--- a/src/Flare.php
+++ b/src/Flare.php
@@ -207,11 +207,11 @@ class Flare
 
     protected function shouldSendReport(Throwable $throwable): bool
     {
-        if($this->reportErrorLevels && $throwable instanceof Error){
+        if ($this->reportErrorLevels && $throwable instanceof Error) {
             return $this->reportErrorLevels & $throwable->getCode();
         }
 
-        if($this->reportErrorLevels && $throwable instanceof ErrorException){
+        if ($this->reportErrorLevels && $throwable instanceof ErrorException) {
             return $this->reportErrorLevels & $throwable->getSeverity();
         }
 

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -3,6 +3,7 @@
 namespace Facade\FlareClient\Tests;
 
 use Error;
+use ErrorException;
 use Facade\FlareClient\Api;
 use Facade\FlareClient\Enums\MessageLevels;
 use Facade\FlareClient\Flare;
@@ -351,6 +352,22 @@ class FlareTest extends TestCase
 
         $this->reportError(E_NOTICE);
         $this->reportError(E_WARNING);
+
+        $this->fakeClient->assertRequestsSent(3);
+    }
+
+    /** @test */
+    public function it_can_filter_error_exceptions_based_on_their_severity()
+    {
+        $this->flare->report(new ErrorException('test', 0, E_NOTICE));
+        $this->flare->report(new ErrorException('test', 0, E_WARNING));
+
+        $this->fakeClient->assertRequestsSent(2);
+
+        $this->flare->reportErrorLevels(E_ALL & ~E_NOTICE);
+
+        $this->flare->report(new ErrorException('test', 0, E_NOTICE));
+        $this->flare->report(new ErrorException('test', 0, E_WARNING));
 
         $this->fakeClient->assertRequestsSent(3);
     }

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -2,6 +2,7 @@
 
 namespace Facade\FlareClient\Tests;
 
+use Error;
 use Facade\FlareClient\Api;
 use Facade\FlareClient\Enums\MessageLevels;
 use Facade\FlareClient\Flare;
@@ -9,6 +10,7 @@ use Facade\FlareClient\Tests\Concerns\MatchesReportSnapshots;
 use Facade\FlareClient\Tests\Mocks\FakeClient;
 use Facade\FlareClient\Tests\TestClasses\ExceptionWithContext;
 use PHPUnit\Framework\Exception;
+use Throwable;
 
 class FlareTest extends TestCase
 {
@@ -42,6 +44,14 @@ class FlareTest extends TestCase
 
         $this->flare->report($throwable);
     }
+
+    protected function reportError(int $code)
+    {
+        $throwable = new Error('This is a test', $code);
+
+        $this->flare->report($throwable);
+    }
+
 
     /** @test */
     public function it_can_report_an_exception()
@@ -303,5 +313,45 @@ class FlareTest extends TestCase
         $payload = $this->fakeClient->getLastPayload();
 
         $this->assertEquals('123', $payload['application_version']);
+    }
+
+    /** @test */
+    public function it_can_filter_exceptions_being_reported()
+    {
+        $this->reportException();
+
+        $this->fakeClient->assertRequestsSent(1);
+
+        $this->flare->filterExceptionsUsing(function (Throwable $exception) {
+            return false;
+        });
+
+        $this->reportException();
+
+        $this->fakeClient->assertRequestsSent(1);
+
+        $this->flare->filterExceptionsUsing(function (Throwable $exception) {
+            return true;
+        });
+
+        $this->reportException();
+
+        $this->fakeClient->assertRequestsSent(2);
+    }
+
+    /** @test */
+    public function it_can_filter_errors_based_on_their_level()
+    {
+        $this->reportError(E_NOTICE);
+        $this->reportError(E_WARNING);
+
+        $this->fakeClient->assertRequestsSent(2);
+
+        $this->flare->reportErrorLevels(E_ALL & ~E_NOTICE);
+
+        $this->reportError(E_NOTICE);
+        $this->reportError(E_WARNING);
+
+        $this->fakeClient->assertRequestsSent(3);
     }
 }


### PR DESCRIPTION
- Filter PHP errors by their level, for example: `E_ALL & ~E_NOTICE`
- FIlter exceptions via a callable

Can also be used within a Laravel install!

For errors:

```php
Flare::reportErrorLevels(E_ALL & ~E_USER_NOTICE);
```

For exceptions:
```php
Flare::filterExceptionsUsing(fn(Throwable $throwable) => false);
```

By default, these filters are disabled.