### PR TITLE
Add support for report filtering

### DIFF
--- a/src/Flare.php
+++ b/src/Flare.php
@@ -58,6 +58,9 @@ class Flare
 
     /** @var callable|null */
     protected $filterExceptionsCallable;
+    
+    /** @var callable|null */
+    protected $filterReportsCallable;    
 
     public static function register(string $apiKey, string $apiSecret = null, ContextDetectorInterface $contextDetector = null, Container $container = null)
     {
@@ -81,6 +84,11 @@ class Flare
         $this->filterExceptionsCallable = $filterExceptionsCallable;
     }
 
+    public function filterReportsUsing(callable $filterReportsCallable)
+    {
+        $this->filterReportsCallable = $filterReportsCallable;
+    }
+    
     /**
      * @return null|string
      */
@@ -242,6 +250,12 @@ class Flare
 
     private function sendReportToApi(Report $report)
     {
+        if ($this->filterReportsCallable) {
+            if (! call_user_func($this->filterReportsCallable, $report)) {
+                return;
+            }
+        }
+
         try {
             $this->api->report($report);
         } catch (Exception $exception) {


### PR DESCRIPTION
Adds the ability to prevent reports from being sent.

The motivation behind it that we need a way to dynamically allow/disallow reports from being sent, for example based on user preferences since we plan on introducing this on self hosted project(librenms).

(setting `flare.key` to null does nothing since the Client instance is setup on boot already)

Compared to `filterExceptionsCallable` it can also prevent logs and errors from being sent, and that's why it's in `sendReportToApi()` instead of `shouldSendReport()`

Usage is something like this:
```php
Flare::filterReportsUsing(function(Report $report) {
  return false;
});
```